### PR TITLE
Rest client hawk header fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ target
 .classpath
 .project
 .settings
+.idea
+*.iml
 
 # OS generated files #
 ######################

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.monarchapis</groupId>
 	<artifactId>rest-client</artifactId>
-	<version>0.8.1</version>
+	<version>0.8.4</version>
 
 	<parent>
 		<groupId>org.sonatype.oss</groupId>
@@ -135,12 +135,12 @@
 
 	<reporting>
 		<plugins>
-			<!--javaoc -->
+			<!--javadoc -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
 				<version>2.10.1</version>
-				<configuration></configuration>
+				<configuration/>
 			</plugin>
 
 			<!--findbugs -->

--- a/src/main/java/com/monarchapis/client/authentication/HawkV1RequestProcessor.java
+++ b/src/main/java/com/monarchapis/client/authentication/HawkV1RequestProcessor.java
@@ -110,8 +110,6 @@ public class HawkV1RequestProcessor implements RequestProcessor {
 
 			URI uri = URI.create(client.getUrl());
 
-			System.out.println("HawkV1RequestProcessor::getHawkHeader");
-
 			sb.append("hawk.1.header\n");
 			sb.append(ts);
 			sb.append("\n");

--- a/src/main/java/com/monarchapis/client/authentication/HawkV1RequestProcessor.java
+++ b/src/main/java/com/monarchapis/client/authentication/HawkV1RequestProcessor.java
@@ -110,6 +110,8 @@ public class HawkV1RequestProcessor implements RequestProcessor {
 
 			URI uri = URI.create(client.getUrl());
 
+			System.out.println("HawkV1RequestProcessor::getHawkHeader");
+
 			sb.append("hawk.1.header\n");
 			sb.append(ts);
 			sb.append("\n");
@@ -118,6 +120,12 @@ public class HawkV1RequestProcessor implements RequestProcessor {
 			sb.append(client.getMethod());
 			sb.append("\n");
 			sb.append(uri.getRawPath());
+
+			if (uri.getRawQuery() != null) {
+				sb.append("?");
+				sb.append(uri.getRawQuery());
+			}
+
 			sb.append("\n");
 			sb.append(uri.getHost());
 			sb.append("\n");


### PR DESCRIPTION
Added the query string when building the hawk header because it's expected by the HawkV1Authenticator when the server authenticates the request.

Also updated version number to 0.8.4 to match current api-manager release.
